### PR TITLE
Use _signed instead of _s so that this matches the tutorial.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@
 
 COLOR ?= always # Valid COLOR options: {always, auto, never}
 CARGO = cargo --color $(COLOR)
+TARGET = target/wasm32-unknown-unknown/debug
 
 .PHONY: all bench build check clean doc test update
 
@@ -24,7 +25,7 @@ bench:
 
 build:
 	@$(CARGO) build
-	wascap sign target/wasm32-unknown-unknown/debug/{{crate_name}}.wasm target/wasm32-unknown-unknown/debug/{{crate_name}}_s.wasm -a ./.keys/account.nk -m ./.keys/module.nk -s
+	wascap sign $(TARGET)/{{crate_name}}.wasm $(TARGET)/{{crate_name}}_signed.wasm -a ./.keys/account.nk -m ./.keys/module.nk -s
 
 check:
 	@$(CARGO) check


### PR DESCRIPTION
This is largely a cosmetic change to make the output of `make build` the same as the tutorial's suggested naming convention. The tutorial currently dumps the signed WASM in the working directory, but it does seem like putting it in the target directory is better.

Signed-off-by: Matt Butcher <matt.butcher@microsoft.com>