### PR TITLE
Update wascc-actor dependency to latest (0.7.1)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 crate-type = ["cdylib"]
 
 [dependencies]
-wascc-actor = "0.6.0"
+wascc-actor = "0.7.1"
 
 [profile.release]
 # Optimize for small code size


### PR DESCRIPTION
version 0.6.0 was failing to recognize the 'HandlerResult' type as defined in the latest version of wascc-actor/src/lib.rs